### PR TITLE
Fix typo option authRedirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The url for logging in.
 
 Url method for registering a user.
 
-**`loginRedirect`**
+**`authRedirect`**
 
 **default:** '/login'
 


### PR DESCRIPTION
Fix typo option from `loginRedirect` to `authRedirect`